### PR TITLE
Updating the array passed to filter pmproship_required_shipping_fields

### DIFF
--- a/pmpro-shipping.php
+++ b/pmpro-shipping.php
@@ -421,16 +421,14 @@ function pmproship_pmpro_registration_checks( $okay ) {
 	if ( empty( $_REQUEST['sameasbilling'] ) ) {
 		global $pmpro_msg, $pmpro_msgt, $pmpro_error_fields;
 		
-		$required_shipping_fields = array(
-			'sfirstname',
-			'slastname',
-			'saddress1',
-			'scity',
-			'sstate',
-			'szipcode',
-			'sphone',
-			'scountry',
-		);
+		$required_shipping_fields['sfirstname'] = $sfirstname;
+		$required_shipping_fields['slastname'] = $slastname;
+		$required_shipping_fields['saddress1'] = $saddress1;
+		$required_shipping_fields['scity'] = $scity;
+		$required_shipping_fields['sstate'] = $sstate;
+		$required_shipping_fields['szipcode'] = $szipcode;
+		$required_shipping_fields['sphone'] = $sphone;
+		$required_shipping_fields['scountry'] = $scountry;
 		
 		$required_shipping_fields = apply_filters( "pmproship_required_shipping_fields", $required_shipping_fields );
 		


### PR DESCRIPTION
The array for $required_shipping_fields is now an associative array so items can be filtered by name not position in array. This will make it easier to use this filter.