### PR TITLE
* [BUGFIXING] Shipping address info is incorrect from the edit order …

### DIFF
--- a/pmpro-shipping.php
+++ b/pmpro-shipping.php
@@ -240,6 +240,19 @@ function pmproship_pmpro_email_body( $body, $pmpro_email ) {
 		$user_id = $user->ID;
 	}
 
+	if ( class_exists( 'MemberOrder' ) ) {
+		//Get the order from the email. We need to determine if the user coming matches with order user.
+		$order_id = isset( $pmpro_email->data['order_id'] ) ? $pmpro_email->data['order_id'] : null;
+		//if we have an order_id, we can get the user_id from the order
+		if( ! empty( $order_id ) ) {
+			$order = new MemberOrder( $order_id );
+			//If the user id from the order is different from the user id from the email, we will use the user id from the order.
+			if( $user_id != $order->user_id ) {
+				$user_id = $order->user_id;
+			}
+		}
+	}
+
 	if ( ! empty( $user_id ) ) {
 		//does the user being emailed have a shipping address?
 		$sfirstname = get_user_meta( $user_id, "pmpro_sfirstname", true );


### PR DESCRIPTION
…page if the email passed doens't match with the order user

 * check if the order's user matches with the user from the pmpro email class.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-shipping/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-shipping/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
check if the order's user matches with the user from the pmpro email class. and if not set the user id from the order to grab shipping address info. The reason is there's a bug when users send the email to a different user from the edit order page.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

[BUGFIXING] Added a check to bring the proper user info when send the email from the edit order page.
